### PR TITLE
Add option to hash contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ activate :app_cache do |config|
     '/' => 'offline.html'
   }
   config.use_relative = false
+  config.version_hash = true
 end
 ```
 
@@ -57,6 +58,8 @@ The above configuration will generate the following appcache:
 
 ```manifest.appcache
 CACHE MANIFEST
+
+# version 1aadc03fe3f695a96d64f1a190b6253e
 
 CACHE:
 /index.html
@@ -111,6 +114,12 @@ The mapping of fallback resources if a resource is unavailable.
 ### use_relative
 
 If the resources should be treated as relative from the appcache.
+
+**Default:** `true`
+
+### version_hash
+
+If a version hash should be generated from the contents of the referenced files.
 
 **Default:** `true`
 

--- a/lib/middleman-appcache/version.rb
+++ b/lib/middleman-appcache/version.rb
@@ -1,7 +1,7 @@
 module Middleman
 
   module AppCache
-    VERSION = '1.0.1'
+    VERSION = '1.1.0'
   end
 
 end


### PR DESCRIPTION
By hashing the contents and adding it as a comment, the manifest will be different every time the contents of the files changes, meaning the client will re-fetch the data.
