### PR TITLE
use builder.trigger instead of builder.say status

### DIFF
--- a/lib/middleman-appcache/extension.rb
+++ b/lib/middleman-appcache/extension.rb
@@ -73,7 +73,7 @@ module Middleman
           end
         end
 
-        builder.say_status :regenerated, cache_manifest_filename
+         builder.trigger :created, manifest_file
       end
     end
 


### PR DESCRIPTION
Updated to use builder.trigger instead of builder.say_status for correct output of status message in terminal with Middleman 4 per https://github.com/middleman/middleman/issues/1492. Updated same line to use recognized builder event mode :dreated instead of :regenerated and full file name.
